### PR TITLE
Example test dependency on src proto which fails.

### DIFF
--- a/testProject/src/test/proto/test_src_dependency.proto
+++ b/testProject/src/test/proto/test_src_dependency.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+import "com/example/tutorial/sample.proto";
+
+message TestMessage {
+  Msg msg = 1;
+}


### PR DESCRIPTION
Fails with:
protoc: stdout: . stderr: com/example/tutorial/sample.proto: File not found.
  test_src_dependency.proto: Import "com/example/tutorial/sample.proto" was not found or had errors.
  test_src_dependency.proto:6:3: "Msg" is not defined.
